### PR TITLE
feature/86cuvrgew add location recommendation in the location form input

### DIFF
--- a/behind-the-veil-siteroot/imports/ui/components/pages/profile/settings/ArtistServiceArea.jsx
+++ b/behind-the-veil-siteroot/imports/ui/components/pages/profile/settings/ArtistServiceArea.jsx
@@ -5,6 +5,8 @@
  */
 import React, {useState} from "react";
 import {CheckIcon} from "@heroicons/react/24/outline";
+import { mapboxKey } from "./../../../../components/map/mapUtils.js";
+import {AddressAutofill} from "@mapbox/search-js-react";
 
 import Input from "../../../input/Input";
 import Button from "../../../button/Button.jsx";
@@ -57,14 +59,16 @@ export const ArtistServiceArea = () => {
         <form className="flex flex-col items-left justify-center gap-y-6 pl-[5%] lg:pl-[15%]" onSubmit={handleSaveChanges}>
             <div className="flex flex-col items-left justify-center md:flex-row md:items-center md:justify-start gap-6">
                 {/*Service Location input*/}
-                <Input
-                    type="text"
-                    label={<label className={"main-text"}>Service Location</label>}
-                    placeholder={user.profile.artistServiceLocation}
-                    className="lg:w-[40vw] sm:w-96"
-                    value={location}
-                    onChange={(e) => setLocation(e.target.value)}
-                />
+                <AddressAutofill accessToken = {mapboxKey} >
+                    <Input
+                        type="text"
+                        label={<label className={"main-text"}>Service Location</label>}
+                        placeholder={user.profile.artistServiceLocation}
+                        className="lg:w-[40vw] sm:w-96"
+                        value={location}
+                        onChange={(e) => setLocation(e.target.value)}
+                    />
+                </AddressAutofill>
                 {/*Radius input*/}
                 <Input
                     type="number"

--- a/behind-the-veil-siteroot/imports/ui/components/pages/profile/settings/ArtistServiceArea.jsx
+++ b/behind-the-veil-siteroot/imports/ui/components/pages/profile/settings/ArtistServiceArea.jsx
@@ -3,10 +3,10 @@
  * File version: 1.1
  * Contributors: Hirun, Nikki
  */
-import React, {useEffect, useState} from "react";
-import {CheckIcon} from "@heroicons/react/24/outline";
+import React, { useEffect, useState } from "react";
+import { CheckIcon } from "@heroicons/react/24/outline";
 import { mapboxKey } from "./../../../../components/map/mapUtils.js";
-import {AddressAutofill} from "@mapbox/search-js-react";
+import { AddressAutofill } from "@mapbox/search-js-react";
 
 import Input from "../../../input/Input";
 import Button from "../../../button/Button.jsx";
@@ -44,7 +44,7 @@ export const ArtistServiceArea = () => {
                             reject(error);
                         } else {
                             setLocation('');
-                            setRadius(''); 
+                            setRadius('');
                             setSuccessMessage('Service Area changed successfully!');
                             resolve(user._id);
                         }
@@ -66,17 +66,17 @@ export const ArtistServiceArea = () => {
         <form className="flex flex-col items-left justify-center gap-y-6 pl-[5%] lg:pl-[15%]" onSubmit={handleSaveChanges}>
             <div className="flex flex-col items-left justify-center md:flex-row md:items-center md:justify-start gap-6">
                 {/*Service Location input*/}
-                <AddressAutofill accessToken = {mapboxKey} onRetrieve={(e) => {
+                <AddressAutofill accessToken={mapboxKey} onRetrieve={(e) => {
                     setFullAddress(e.features[0].properties.full_address)
-                }
-                }>
+                }}>
                     <Input
                         type="text"
                         label={<label className={"main-text"}>Service Location</label>}
                         placeholder={user.profile.artistServiceLocation}
                         className="lg:w-[40vw] sm:w-96"
                         value={location}
-                        onChange={(e) => {setLocation(e.target.value)
+                        onChange={(e) => {
+                            setLocation(e.target.value)
                         }}
                     />
                 </AddressAutofill>

--- a/behind-the-veil-siteroot/imports/ui/components/pages/profile/settings/ArtistServiceArea.jsx
+++ b/behind-the-veil-siteroot/imports/ui/components/pages/profile/settings/ArtistServiceArea.jsx
@@ -3,7 +3,7 @@
  * File version: 1.1
  * Contributors: Hirun, Nikki
  */
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import {CheckIcon} from "@heroicons/react/24/outline";
 import { mapboxKey } from "./../../../../components/map/mapUtils.js";
 import {AddressAutofill} from "@mapbox/search-js-react";
@@ -55,18 +55,29 @@ export const ArtistServiceArea = () => {
 
     };
 
+    const [fullAddress, setFullAddress] = useState('')
+
+    // to overwrite the location state with the full address when an autocomplete suggestion is selected
+    useEffect(() => {
+        setLocation(fullAddress)
+    }, [fullAddress])
+
     return (
         <form className="flex flex-col items-left justify-center gap-y-6 pl-[5%] lg:pl-[15%]" onSubmit={handleSaveChanges}>
             <div className="flex flex-col items-left justify-center md:flex-row md:items-center md:justify-start gap-6">
                 {/*Service Location input*/}
-                <AddressAutofill accessToken = {mapboxKey} >
+                <AddressAutofill accessToken = {mapboxKey} onRetrieve={(e) => {
+                    setFullAddress(e.features[0].properties.full_address)
+                }
+                }>
                     <Input
                         type="text"
                         label={<label className={"main-text"}>Service Location</label>}
                         placeholder={user.profile.artistServiceLocation}
                         className="lg:w-[40vw] sm:w-96"
                         value={location}
-                        onChange={(e) => setLocation(e.target.value)}
+                        onChange={(e) => {setLocation(e.target.value)
+                        }}
                     />
                 </AddressAutofill>
                 {/*Radius input*/}


### PR DESCRIPTION
ticket: https://app.clickup.com/t/86cuvrgew
route: http://localhost:3000/profile/settings (service area tab)

Note: 
- used the mapbox AddressAutofill that was already implemented in the booking request form
- shows recommendation but not all locations (e.g. Monash University Clayton doesn't show up)
- locations with same name may not select the one intended
- is still able to select locations outside of the suggestion