### PR TITLE
Feature/86cuw4kdk Calendar booking status colour change

### DIFF
--- a/behind-the-veil-siteroot/imports/ui/components/booking/BookingCalendarView.jsx
+++ b/behind-the-veil-siteroot/imports/ui/components/booking/BookingCalendarView.jsx
@@ -136,12 +136,21 @@ const BookingCalendarView = ({ bookingsData }) => {
         events={events}
         eventPropGetter={(myEventsList) => {
           let backgroundColor;
+          let className;
           if (myEventsList.bookingStatus === BookingStatus.CONFIRMED) {
-            backgroundColor = "green";
+            backgroundColor = "#27AD6D";
+          } else if (myEventsList.bookingStatus === BookingStatus.COMPLETED) {
+            backgroundColor = "#27AD6D";
           } else if (myEventsList.bookingStatus === BookingStatus.PENDING) {
-            backgroundColor = "blue";
+            backgroundColor = "#4F76D9";
+          } else if (myEventsList.bookingStatus === BookingStatus.CANCELLED) {
+            backgroundColor = "#D33B3B";
+          } else if (myEventsList.bookingStatus === BookingStatus.REJECTED) {
+            backgroundColor = "#D33B3B";
+          } else if (myEventsList.bookingStatus === BookingStatus.OVERDUE) {
+            backgroundColor = "#D33B3B";
           } else {
-            backgroundColor = "red";
+            backgroundColor = "#D33B3B";
           }
 
           return { style: { backgroundColor } };


### PR DESCRIPTION
When logged in as an artist, go to calendar bookings and the bookings should now be the correct corresponding colours as in tailwind file