### PR TITLE
86cvpz73a: dashboard values aligned

### DIFF
--- a/behind-the-veil-siteroot/client/main.css
+++ b/behind-the-veil-siteroot/client/main.css
@@ -70,6 +70,13 @@
         line-height: 150%;
     }
 
+    .medium-number-text {
+        @apply text-our-black;
+        font-size: 30px;
+        font-weight: 400;
+        line-height: 150%;
+    }
+
     .logo-text {
         /* TODO: font should be poppins */
         @apply text-our-black;

--- a/behind-the-veil-siteroot/imports/ui/components/card/DashboardCard.jsx
+++ b/behind-the-veil-siteroot/imports/ui/components/card/DashboardCard.jsx
@@ -18,40 +18,44 @@ import Card from "./Card";
  * @param cardProps encompasses all other props supplied and applies them to the card
  */
 export const DashboardCard = ({
-                                  className,
-                                  dashboardCardTitle,
-                                  dashboardCardDesc,
-                                  dashboardCardValue,
-                                  ...cardProps
-                              }) => {
-    // variables to handle routing
-    const classes = classNames(className,
-        "flex flex-col justify-center items-center gap-x-8 cursor-default " +
-        "sm:flex-row sm:grid sm:grid-cols-5 " +
-        "lg:flex-col lg:grid-cols-none " +
-        "xl:flex-row xl:grid xl:grid-cols-5 " +
-        "w-full min-w-60 lg:w-2/5 lg:min-w-[300px] min-h-48");
+  className,
+  dashboardCardTitle,
+  dashboardCardDesc,
+  dashboardCardValue,
+  ...cardProps
+}) => {
+  // variables to handle routing
+  const classes = classNames(
+    className,
+    "flex flex-col justify-center items-center gap-x-8 cursor-default " +
+      "sm:flex-row sm:grid sm:grid-cols-5 " +
+      "lg:flex-col lg:grid-cols-none " +
+      "xl:flex-row xl:grid xl:grid-cols-5 " +
+      "w-full min-w-60 lg:w-2/5 lg:min-w-[300px] min-h-48"
+  );
 
-    return (
-        <Card className={classes} {...cardProps}>
+  return (
+    <Card className={classes} {...cardProps}>
+      <div
+        className="flex flex-col w-full max-w-[250px] h-fit
+            col-span-full sm:col-span-3 lg:col-span-full xl:col-span-3"
+      >
+        <div className="large-text text-wrap text-our-black max-w-full mb-3 text-center">
+          {dashboardCardTitle}
+        </div>
+        <div className="small-text text-dark-grey max-h-[5.5rem] max-w-full line-clamp-4 mb-3 text-center">
+          {dashboardCardDesc}
+        </div>
+      </div>
 
-            <div className="flex flex-col w-full max-w-[250px] h-fit
-            col-span-full sm:col-span-3 lg:col-span-full xl:col-span-3">
-                <div
-                    className="large-text text-wrap text-our-black max-w-full mb-3 text-center">
-                    {dashboardCardTitle}
-                </div>
-                <div className="small-text text-dark-grey max-h-[5.5rem] max-w-full line-clamp-4 mb-3 text-center">
-                    {dashboardCardDesc}
-                </div>
-            </div>
-
-            <div className="text-our-black text-center large-number-text w-fit min-w-1/4 break-all line-clamp-1
-            col-span-full sm:col-span-2 lg:col-span-full lg:w-full xl:col-span-2 xl:w-fit">
-                {dashboardCardValue}
-            </div>
-        </Card>
-    );
+      <div
+        className="text-our-black text-center mx-auto large-number-text md:medium-number-text w-fit min-w-1/4 break-all line-clamp-1
+          col-span-full sm:col-span-2 lg:col-span-full lg:w-full xl:col-span-2 xl:w-fit"
+      >
+        {dashboardCardValue}
+      </div>
+    </Card>
+  );
 };
 
 export default DashboardCard;


### PR DESCRIPTION
**Ticket:**
https://app.clickup.com/t/86cvpz73a

Dashboard figures (i.e. $x dollars earnt in "Total Earnings") should now look better, with center aligned and not overflowing.
Changed the font sizing and added responsiveness (although not sure if added correctly).

**Instructions:**

1. Create artist account
2. Go into Dashboard Tab
3. Check to see if figures and values are centered.
 
**Results:**
Prior to bug fix:
![363812116-80cce492-76e1-44f4-a169-4510ac378d05](https://github.com/user-attachments/assets/82643327-11fa-4bee-8205-f40465f2dc78)

After bug fix:
![Screenshot 2024-09-10 at 11 17 17 AM](https://github.com/user-attachments/assets/0f073525-6142-4188-9665-ce8ae011bf92)