### PR TITLE
feature/86cuw4kmt: Red dot on artist booking tab added when the artist has a booking they haven't responded to

### DIFF
--- a/behind-the-veil-siteroot/imports/ui/components/pages/profile/ArtistProfileTabs.jsx
+++ b/behind-the-veil-siteroot/imports/ui/components/pages/profile/ArtistProfileTabs.jsx
@@ -1,10 +1,10 @@
 /**
  * File Description: Artist profile page tabs
- * File version: 2.0
- * Contributors: Kefei (Phillip) Li, Laura, Nikki, Lucas
+ * File version: 2.1
+ * Contributors: Kefei (Phillip) Li, Laura, Nikki, Lucas, Vicky
  */
 
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 import Tabs from "../../tabs/Tabs.jsx";
 import ArtistDashboardTab from "./artistTabs/ArtistDashboardTab";
@@ -12,6 +12,9 @@ import ArtistGalleryTab from "./artistTabs/ArtistGalleryTab";
 import ArtistBookingsTab from "./artistTabs/ArtistBookingsTab";
 import ArtistServicesTab from "./artistTabs/ArtistServicesTab";
 import ArtistReviewsTab from "./artistTabs/ArtistReviewsTab";
+import BookingStatus from "../../../enums/BookingStatus";
+
+import { useUserBookings } from "../../DatabaseHelper.jsx";
 
 /**
  * Component for artist's profile tabs
@@ -19,12 +22,43 @@ import ArtistReviewsTab from "./artistTabs/ArtistReviewsTab";
  * @param userInfo - logged-in user information passed in
  */
 export const ArtistProfileTabs = ({ userInfo }) => {
+  // Variable for tracking if there bookings the artist hasn't yet responded to
+  const [unrespondedBookings, setUnrespondedBookings] = useState(false);
+
+  // Get the artist booking details
+  const { isLoadingUserBooking, artistBookingData } = useUserBookings(userInfo.username);
+  const isLoading = isLoadingUserBooking();
+
+  // Loop through artist booking data to identify if there is a booking the artist hasn't responded to
+  useEffect(() => {
+      if (isLoading || artistBookingData == undefined) return;
+
+      let hasPendingBooking = false;
+
+      if (artistBookingData.length > 0) {
+        for (let i = 0; i < artistBookingData.length; i++) {
+          if (artistBookingData[i].bookingStatus == BookingStatus.PENDING) {
+            hasPendingBooking = true;
+            break;
+          }
+        }
+      }
+
+      if (unrespondedBookings !== hasPendingBooking) {
+        setUnrespondedBookings(hasPendingBooking);
+      }
+
+  }, [isLoading, artistBookingData, unrespondedBookings])
+
   // Utilise Tab components to create page schematics.
   return (
     <Tabs
       tabs={[
         <span key={1}>Dashboard</span>,
-        <span key={2}>Bookings</span>,
+        <span key={2} className="relative" >Bookings
+          {/* Display a red dot to indicate that a booking has not been responded to */}
+          {unrespondedBookings && (<span className="absolute top-0 h-2 w-2 bg-red-500 rounded-full"></span>)}
+        </span>,
         <span key={3}>My Services</span>,
         <span key={4}>Gallery</span>,
         <span key={5}>Reviews</span>,


### PR DESCRIPTION
This branch was focused on adding the red dot to the artist's booking tab to indicate when they have a booking they haven't responded to. When the artist has responded to all bookings, the red dot will not appear. 